### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -28,7 +28,7 @@ jobs:
       uses: managedkaos/print-env@v1.0
 
     - name: Build & Publish to Github Package
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}/${{ env.DOCKER_REPO_NAME }}
         username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
 
     - name: Build & Publish to Github Container Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.actor }}/${{ env.DOCKER_REPO_NAME }}
         username: ${{ github.actor }}
@@ -48,7 +48,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}
         username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       uses: managedkaos/print-env@v1.0
 
     - name: Build & Publish to Github Package
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}/${{ env.DOCKER_REPO_NAME }}
         username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
         
     - name: Build & Publish to Github Container Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.actor }}/${{ env.DOCKER_REPO_NAME }}
         username: ${{ github.actor }}
@@ -46,7 +46,7 @@ jobs:
         tags: "${{ env.IMAGE_TAG }}"
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ github.repository }}
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore